### PR TITLE
Update DAQModuleHelper method names (changed on appfwk develop)

### DIFF
--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -68,8 +68,8 @@ void
 CTBModule::init(const nlohmann::json& init_data)
 {
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
-  m_llt_hsi_data_sender = get_iom_sender<dunedaq::hsilibs::HSI_FRAME_STRUCT>(appfwk::connection_inst(init_data, "llt_output"));
-  m_hlt_hsi_data_sender = get_iom_sender<dunedaq::hsilibs::HSI_FRAME_STRUCT>(appfwk::connection_inst(init_data, "hlt_output"));
+  m_llt_hsi_data_sender = get_iom_sender<dunedaq::hsilibs::HSI_FRAME_STRUCT>(appfwk::connection_uid(init_data, "llt_output"));
+  m_hlt_hsi_data_sender = get_iom_sender<dunedaq::hsilibs::HSI_FRAME_STRUCT>(appfwk::connection_uid(init_data, "hlt_output"));
 
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }


### PR DESCRIPTION
v3.2.x added some calls to `appfwk::connection_inst`, but in the meantime, the name of the method was changed to `appfwk::connection_uid` in `develop`.