### PR TITLE
Reorganize daqconf schema options

### DIFF
--- a/python/ctbmodules/apps/ctb_hsi_gen.py
+++ b/python/ctbmodules/apps/ctb_hsi_gen.py
@@ -44,23 +44,27 @@ def update_triggers(updated_triggers, default_trigger_conf):
 
 
 def get_ctb_hsi_app(
+        ctb_hsi,
         nickname,
         LLT_SOURCE_ID,
         HLT_SOURCE_ID,
         QUEUE_POP_WAIT_MS=10,
         LATENCY_BUFFER_SIZE=100000,
         DATA_REQUEST_TIMEOUT=1000,
-        HOST="localhost",
-        HLT_LIST=None,
-        BEAM_LLT_LIST=None,
-        CRT_LLT_LIST=None,
-        PDS_LLT_LIST=None,
-        FAKE_TRIG_1=None,
-        FAKE_TRIG_2=None
 ):
     '''
     Here an entire application controlling one CTB board is generated. 
     '''
+
+    # Temp variables - Remove
+    HOST=ctb_hsi.host_ctb_hsi
+    HLT_LIST=ctb_hsi.hlt_triggers
+    BEAM_LLT_LIST=ctb_hsi.beam_llt_triggers
+    CRT_LLT_LIST=ctb_hsi.crt_llt_triggers
+    PDS_LLT_LIST=ctb_hsi.pds_llt_triggers
+    FAKE_TRIG_1=ctb_hsi.fake_trig_1
+    FAKE_TRIG_2=ctb_hsi.fake_trig_2
+
     console = Console()
 
     # Define modules

--- a/schema/ctbmodules/confgen.jsonnet
+++ b/schema/ctbmodules/confgen.jsonnet
@@ -1,21 +1,24 @@
 // This is the configuration schema for timinglibs
 
 local moo = import "moo.jsonnet";
-local sdc = import "daqconf/confgen.jsonnet";
-local daqconf = moo.oschema.hier(sdc).dunedaq.daqconf.confgen;
+
+local stypes = import "daqconf/types.jsonnet";
+local types = moo.oschema.hier(stypes).dunedaq.daqconf.types;
+
+local sboot = import "daqconf/bootgen.jsonnet";
+local bootgen = moo.oschema.hier(sboot).dunedaq.daqconf.bootgen;
 
 local ns = "dunedaq.ctbmodules.confgen";
 local s = moo.oschema.schema(ns);
 
 // A temporary schema construction context.
 local cs = {
-  number: s.number  ("number", "i8", doc="a number"), // !?!?!
 
   ctbmodules_gen: s.record('ctbmodules_gen', [
-    s.field('boot',                      daqconf.boot,                   default=daqconf.boot,                   doc='Boot parameters'),
+    s.field('boot',     bootgen.boot, default=bootgen.boot, doc='Boot parameters'),
   ]),
 
 };
 
 // Output a topologically sorted array.
-sdc + moo.oschema.sort_select(cs, ns)
+stypes + sboot + moo.oschema.sort_select(cs, ns)


### PR DESCRIPTION
Implement the code confgen parameters reorganisation described in https://github.com/DUNE-DAQ/daqconf/pull/330 and https://github.com/DUNE-DAQ/daqconf/pull/354