### PR TITLE
Resolve matching errors caused by racing condition in word serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(ctbmodules VERSION 2.3.0)
+project(ctbmodules VERSION 3.0.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -56,7 +56,6 @@ CTBModule::CTBModule(const std::string& name)
   , m_num_control_messages_sent(0)
   , m_num_control_responses_received(0)
   , m_last_readout_hlt_timestamp(0)
-  , m_last_readout_llt_timestamp(0)
 {
   register_command("conf", &CTBModule::do_configure);
   register_command("start", &CTBModule::do_start);
@@ -251,6 +250,8 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
   bool connection_closed = false ;
   uint64_t ch_stat_beam, ch_stat_crt, ch_stat_pds;
   uint64_t prev_timestamp = 0;
+  ts_payload prev_hlt, prev_llt, prev_ch_stat;
+  ts_payload curr_hlt, curr_llt, curr_ch_stat;
   // buffers for word matching. buf_a are the trigger words, buf_b are corresponding payloads
   std::queue<content::word::trigger_t> match_buf_a_hlts, match_buf_a_llts;
   std::queue<ts_payload> match_buf_b_llts, match_buf_b_chstatus;
@@ -310,47 +311,54 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
                                                   << " \t Padding -> " << feedback -> padding << std::dec << std::endl ;
       } else if (temp_word.word_type == content::word::t_gt)
       {
-        TLOG_DEBUG(3) << "Received HLT word!";
-        content::word::trigger_t * hlt_word = reinterpret_cast<content::word::trigger_t*>( & temp_word ) ;
+        TLOG_DEBUG(3) << "Received HLT word! TS: " + temp_word.timestamp;
+        content::word::trigger_t * hlt_word = reinterpret_cast<content::word::trigger_t*>( & temp_word );
+        curr_hlt = {hlt_word->timestamp, (hlt_word->trigger_word & 0x1FFFFFFFFFFFFFFF)};
+        if (check_repeated_word(curr_hlt, prev_hlt, temp_word.word_type)) continue;
         match_buf_a_hlts.push(*hlt_word);
-
         // Count the total HLTs and each specific one
         ++m_run_HLT_counter;
         ++m_total_hlt_counter;
         for (auto &hlt : m_hlt_trigger_counter) { if( (hlt_word->trigger_word >> hlt.first) & 0x1 ) ++hlt.second; }
         m_last_readout_hlt_timestamp = temp_word.timestamp;
+        prev_hlt = curr_hlt;
       }
       else if (temp_word.word_type == content::word::t_lt)
       {
-        TLOG_DEBUG(5) << "Received LLT word!";
+        TLOG_DEBUG(5) << "Received LLT word! TS: " + temp_word.timestamp;
         content::word::trigger_t * llt_word = reinterpret_cast<content::word::trigger_t*>( & temp_word ) ;
+        curr_llt = {llt_word->timestamp, (llt_word->trigger_word & 0xFFFFFFFF)};
+        if (check_repeated_word(curr_llt, prev_llt, temp_word.word_type)) continue;
         match_buf_a_llts.push(*llt_word);
-        match_buf_b_llts.push({llt_word->timestamp, (llt_word->trigger_word & 0xFFFFFFFF)});
+        match_buf_b_llts.push(curr_llt);
 
         ++m_run_LLT_counter;
         for (auto &llt : m_llt_trigger_counter) { if( (llt_word->trigger_word >> llt.first) & 0x1 ) ++llt.second; }
-        m_last_readout_llt_timestamp = temp_word.timestamp;
+        prev_llt = curr_llt;
       }
       else if (temp_word.word_type == content::word::t_ch)
       {
 
-        TLOG_DEBUG(5) << "Received Channel Status word!";
         content::word::ch_status_t * ch_stat_word = reinterpret_cast<content::word::ch_status_t*>( & temp_word ) ;
+        // The channel status only has 60b TS so complete the upper 4b from the TS Word. (fyi 60b rolls over >500yr @ 62.5MHz) 
+        uint64_t corrected_ts = ((prev_timestamp & 0xF000000000000000) | ch_stat_word->timestamp);
+        TLOG_DEBUG(6) << "Received Channel Status word! TS: " + corrected_ts;
         ch_stat_beam = ch_stat_word->get_beam();
         ch_stat_crt  = ch_stat_word->get_crt();
         ch_stat_pds  = ch_stat_word->get_pds();
-        // The channel status only has 60b TS so complete the upper 4b from the TS Word. (fyi 60b rolls over >500yr @ 62.5MHz) 
-        match_buf_b_chstatus.push({
-            ((prev_timestamp & 0xF000000000000000) | ch_stat_word->timestamp), 
+        curr_ch_stat = {
+            corrected_ts, 
             ((ch_stat_pds << 48) | (ch_stat_crt << 16) | ch_stat_beam)
-        });
-
+        };
+        if (check_repeated_word(curr_ch_stat, prev_ch_stat, temp_word.word_type)) continue;
+        match_buf_b_chstatus.push(curr_ch_stat);
+        prev_ch_stat = curr_ch_stat;
 
         ++m_run_channel_status_counter;
       }
       // do matching
-      match_between_buffers(match_buf_a_hlts, match_buf_b_llts, m_last_readout_hlt_timestamp.load());
-      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, m_last_readout_llt_timestamp.load());
+      match_between_buffers(match_buf_a_hlts, match_buf_b_llts, prev_hlt.first);
+      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, prev_llt.first);
 
     } // n_words loop
 
@@ -391,6 +399,28 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
   
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
 
+}
+
+bool CTBModule::check_repeated_word(ts_payload& curr_word, ts_payload& prev_word, uint64_t wtype){
+  if (curr_word.first == prev_word.first) { // words with repeated timestamp. Not good!
+    std::stringstream msg;
+    msg << "Multiple words have the same timestamp, Using the first one. Word type: ";
+    if (wtype == content::word::word_type::t_gt) msg << "HLT";
+    else if (wtype == content::word::word_type::t_lt) msg << "LLT";
+    else if (wtype == content::word::word_type::t_ch) msg << "Channel Status";
+    else msg << wtype;
+    msg << ", TS: "<< curr_word.first << ".";
+    if (curr_word.second != prev_word.second) { // not only do we have repeated timestamp, they have different payload...
+      msg << " Different payload!! Previous payload: " << std::hex << prev_word.second
+          << " Current payload: " << curr_word.second;
+      ers::warning(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
+    } else {
+      msg << "Both have payload " << std::hex << prev_word.second;
+      ers::info(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
+    }
+    return true;
+  }
+  return false;
 }
 
 void CTBModule::send_matched_trigger_word(content::word::trigger_t& word, uint64_t payload) {

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -56,6 +56,7 @@ CTBModule::CTBModule(const std::string& name)
   , m_num_control_messages_sent(0)
   , m_num_control_responses_received(0)
   , m_last_readout_hlt_timestamp(0)
+  , m_last_readout_llt_timestamp(0)
 {
   register_command("conf", &CTBModule::do_configure);
   register_command("start", &CTBModule::do_start);
@@ -250,6 +251,9 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
   bool connection_closed = false ;
   uint64_t ch_stat_beam, ch_stat_crt, ch_stat_pds;
   uint64_t prev_timestamp = 0;
+  // buffers for word matching. buf_a are the trigger words, buf_b are corresponding payloads
+  std::queue<content::word::trigger_t> match_buf_a_hlts, match_buf_a_llts;
+  std::queue<ts_payload> match_buf_b_llts, match_buf_b_chstatus;
 
   while (running_flag.load() && !m_stop_requested.load()) {
 
@@ -267,9 +271,6 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
     // read n words as requested from the header
     
     update_buffer_counts(n_words);
-    // buffers for word matching. buf_a are the trigger words, buf_b are corresponding payloads
-    std::queue<content::word::trigger_t> match_buf_a_hlts, match_buf_a_llts;
-    std::queue<ts_payload> match_buf_b_llts, match_buf_b_chstatus;
 
     for ( unsigned int i = 0 ; i < n_words ; ++i ) {
       
@@ -328,6 +329,7 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
 
         ++m_run_LLT_counter;
         for (auto &llt : m_llt_trigger_counter) { if( (llt_word->trigger_word >> llt.first) & 0x1 ) ++llt.second; }
+        m_last_readout_llt_timestamp = temp_word.timestamp;
       }
       else if (temp_word.word_type == content::word::t_ch)
       {
@@ -348,7 +350,7 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
       }
       // do matching
       match_between_buffers(match_buf_a_hlts, match_buf_b_llts, m_last_readout_hlt_timestamp.load());
-      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, m_last_readout_hlt_timestamp.load());
+      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, m_last_readout_llt_timestamp.load());
 
     } // n_words loop
 
@@ -408,7 +410,7 @@ void CTBModule::send_matched_trigger_word(content::word::trigger_t& word, uint64
   hsi_struct[5] = word.trigger_word;     // trigger_map;
   hsi_struct[6] = is_hlt ? m_run_HLT_counter : m_run_LLT_counter; // m_generated_counter;
   int dbg_lvl = is_hlt ? 4 : 6;
-  TLOG_DEBUG(dbg_lvl) << get_name() << ": Formed HSI_FRAME_STRUCT for" << (is_hlt? "HLT" : "LLT")
+  TLOG_DEBUG(dbg_lvl) << get_name() << ": Formed HSI_FRAME_STRUCT for " << (is_hlt? "HLT" : "LLT")
       << std::hex 
       << "0x"   << hsi_struct[0]
       << ", 0x" << hsi_struct[1]
@@ -436,10 +438,11 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
     bool is_hlt = trigger.IsHLT();
     uint64_t trigger_ts = trigger.timestamp;
     uint64_t trigger_word = trigger.trigger_word;
-    if ((timeout_reference - trigger_ts) > 100) {
+    if (timeout_reference > (trigger_ts + 100)) {
       std::stringstream msg;
       msg << "Time out while waiting for a match for the "<< (is_hlt? "HLT" : "LLT")
-          << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
+          << ": TS = " << trigger_ts << ", trigger word = " << trigger_word
+          << " Timeout reference: " << timeout_reference;
       ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
       buf_a.pop();
       continue;
@@ -457,7 +460,7 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
         break;
       }
       else { // buf_b is already past the match window. No matching is found, error!
-        if (is_hlt && (trigger_word == 0x1 || trigger_word == (0x1<< 16))) { // Fake HLTs, no matching is OK
+        if (is_hlt && (trigger_word == 0x1 || trigger_word == (0x1 << 16))) { // Fake HLTs, no matching is OK
           send_matched_trigger_word(trigger, 0);
         } 
         else{
@@ -470,7 +473,9 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
         break;
       }
     } // end loop buf_b
-  }
+  } // end loop buf_a
+  // Don't let buf_b get too long (e.g. when LLT rate is high but HLT rate is low)
+  while (buf_b.size() > 32) buf_b.pop();
 }
 
 

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -249,9 +249,7 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
   boost::system::error_code receiving_error;
   bool connection_closed = false ;
   uint64_t ch_stat_beam, ch_stat_crt, ch_stat_pds;
-  uint64_t llt_payload, channel_payload;
   uint64_t prev_timestamp = 0;
-  std::pair<uint64_t,uint64_t> prev_channel, prev_prev_channel, prev_llt, prev_prev_llt; // pair<timestamp, trigger_payload>
 
   while (running_flag.load() && !m_stop_requested.load()) {
 
@@ -269,6 +267,9 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
     // read n words as requested from the header
     
     update_buffer_counts(n_words);
+    // buffers for word matching. buf_a are the trigger words, buf_b are corresponding payloads
+    std::queue<content::word::trigger_t> match_buf_a_hlts, match_buf_a_llts;
+    std::queue<ts_payload> match_buf_b_llts, match_buf_b_chstatus;
 
     for ( unsigned int i = 0 ; i < n_words ; ++i ) {
       
@@ -309,54 +310,45 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
       } else if (temp_word.word_type == content::word::t_gt)
       {
         TLOG_DEBUG(3) << "Received HLT word!";
-        ++m_run_HLT_counter;
         content::word::trigger_t * hlt_word = reinterpret_cast<content::word::trigger_t*>( & temp_word ) ;
-
-        m_last_readout_hlt_timestamp = hlt_word->timestamp;
-        // Now find the associated LLT
-        // if HLT0, skip matching
-        llt_payload = MatchTriggerInput( hlt_word, prev_llt, prev_prev_llt, true );
-        
-        send_trigger_word(hlt_word, llt_payload);
-    
+        match_buf_a_hlts.push(*hlt_word);
 
         // Count the total HLTs and each specific one
+        ++m_run_HLT_counter;
         ++m_total_hlt_counter;
         for (auto &hlt : m_hlt_trigger_counter) { if( (hlt_word->trigger_word >> hlt.first) & 0x1 ) ++hlt.second; }
+        m_last_readout_hlt_timestamp = temp_word.timestamp;
       }
       else if (temp_word.word_type == content::word::t_lt)
       {
         TLOG_DEBUG(5) << "Received LLT word!";
-        ++m_run_LLT_counter;
         content::word::trigger_t * llt_word = reinterpret_cast<content::word::trigger_t*>( & temp_word ) ;
+        match_buf_a_llts.push(*llt_word);
+        match_buf_b_llts.push({llt_word->timestamp, (llt_word->trigger_word & 0xFFFFFFFF)});
 
-        // Find the matching channel status word
-        channel_payload = MatchTriggerInput( llt_word, prev_channel, prev_prev_channel, false );
-        
-        send_trigger_word(llt_word, channel_payload);
-
-        // store the previous 2 LLTs so we can match to the HLT
-        prev_prev_llt = prev_llt;
-        prev_llt = { llt_word->timestamp, (llt_word->trigger_word & 0xFFFFFFFF) };
-
+        ++m_run_LLT_counter;
         for (auto &llt : m_llt_trigger_counter) { if( (llt_word->trigger_word >> llt.first) & 0x1 ) ++llt.second; }
       }
       else if (temp_word.word_type == content::word::t_ch)
       {
 
         TLOG_DEBUG(5) << "Received Channel Status word!";
-        ++m_run_channel_status_counter;
         content::word::ch_status_t * ch_stat_word = reinterpret_cast<content::word::ch_status_t*>( & temp_word ) ;
-
         ch_stat_beam = ch_stat_word->get_beam();
         ch_stat_crt  = ch_stat_word->get_crt();
         ch_stat_pds  = ch_stat_word->get_pds();
+        // The channel status only has 60b TS so complete the upper 4b from the TS Word. (fyi 60b rolls over >500yr @ 62.5MHz) 
+        match_buf_b_chstatus.push({
+            ((prev_timestamp & 0xF000000000000000) | ch_stat_word->timestamp), 
+            ((ch_stat_pds << 48) | (ch_stat_crt << 16) | ch_stat_beam)
+        });
 
-        // Previous 2 channel status words. The channel status only has 60b TS so complete the upper 4b
-        // from the TS Word. (fyi 60b rolls over >500yr @ 62.5MHz) 
-        prev_prev_channel = prev_channel;
-        prev_channel = { ((prev_timestamp & 0xF000000000000000) | ch_stat_word->timestamp),  ((ch_stat_pds << 48) | (ch_stat_crt << 16) | ch_stat_beam) };
+
+        ++m_run_channel_status_counter;
       }
+      // do matching
+      match_between_buffers(match_buf_a_hlts, match_buf_b_llts, m_last_readout_hlt_timestamp.load());
+      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, m_last_readout_hlt_timestamp.load());
 
     } // n_words loop
 
@@ -399,21 +391,21 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
 
 }
 
-void CTBModule::send_trigger_word(content::word::trigger_t* word, uint64_t payload) {
+void CTBModule::send_matched_trigger_word(content::word::trigger_t& word, uint64_t payload) {
   // Send HSI data to a DLH
   std::array<uint32_t, 7> hsi_struct;
-  bool is_hlt = word->IsHLT();
+  bool is_hlt = word.IsHLT();
   hsi_struct[0] = (is_hlt << 26)            |  // link
                   (CTB_HSI_SLOT_ID << 22)   |  
                   (CTB_HSI_CRATE_ID << 12)  | 
                   (CTB_HSI_DET_ID << 6)     |
                   CTB_HSI_FRAME_VERSION
                   ;
-  hsi_struct[1] = word->timestamp;        // ts low
-  hsi_struct[2] = word->timestamp >> 32;  // ts high
+  hsi_struct[1] = word.timestamp;        // ts low
+  hsi_struct[2] = word.timestamp >> 32;  // ts high
   hsi_struct[3] = payload;                // lower 32b
   hsi_struct[4] = payload >> 32;          // upper 32b (will be 0x0 for llt payloads)
-  hsi_struct[5] = word->trigger_word;     // trigger_map;
+  hsi_struct[5] = word.trigger_word;     // trigger_map;
   hsi_struct[6] = is_hlt ? m_run_HLT_counter : m_run_LLT_counter; // m_generated_counter;
   int dbg_lvl = is_hlt ? 4 : 6;
   TLOG_DEBUG(dbg_lvl) << get_name() << ": Formed HSI_FRAME_STRUCT for" << (is_hlt? "HLT" : "LLT")
@@ -429,13 +421,56 @@ void CTBModule::send_trigger_word(content::word::trigger_t* word, uint64_t paylo
   if (is_hlt) {
     send_raw_hsi_data(hsi_struct, m_hlt_hsi_data_sender.get());
     // TODO properly fill device id
-    dfmessages::HSIEvent event(0x1, word->trigger_word, word->timestamp, m_run_HLT_counter, m_run_number);
+    dfmessages::HSIEvent event(0x1, word.trigger_word, word.timestamp, m_run_HLT_counter, m_run_number);
     send_hsi_event(event);
   }
   else {
     send_raw_hsi_data(hsi_struct, m_llt_hsi_data_sender.get());
   }
   
+}
+
+void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_a, std::queue<ts_payload>& buf_b, uint64_t timeout_reference) {
+  while (buf_a.size() > 0) {
+    content::word::trigger_t trigger = buf_a.front();
+    bool is_hlt = trigger.IsHLT();
+    uint64_t trigger_ts = trigger.timestamp;
+    uint64_t trigger_word = trigger.trigger_word;
+    if ((timeout_reference - trigger_ts) > 100) {
+      std::stringstream msg;
+      msg << "Time out while waiting for a match for the "<< (is_hlt? "HLT" : "LLT")
+          << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
+      ers::warning(CTBWordMatchError(ERS_HERE, msg.str()));
+      buf_a.pop();
+      continue;
+    }
+    if (buf_b.size() == 0) break; // no input to match yet. Return for now, wait for matching input to come
+    while (buf_b.size() > 0) {
+      uint64_t input_ts = buf_b.front().first;
+      if (input_ts < (trigger_ts - 1)) { // word is too early. No longer needed
+        buf_b.pop();
+      }
+      else if (input_ts == (trigger_ts - 1)) { // match is found
+        send_matched_trigger_word(trigger, buf_b.front().second);
+        buf_a.pop();
+        buf_b.pop();
+        break;
+      }
+      else { // buf_b is already past the match window. No matching is found, error!
+        if (is_hlt && (trigger_word == 0x1 || trigger_word == (0x1<< 16))) { // Fake HLTs, no matching is OK
+          send_matched_trigger_word(trigger, 0);
+        } 
+        else{
+          std::stringstream msg;
+          msg << "No match found for " << (is_hlt? "HLT" : "LLT")
+              << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
+          ers::warning(CTBWordMatchError(ERS_HERE, msg.str()));
+        }
+        buf_a.pop();
+        continue;
+      }
+    } // end loop buf_b
+  }
 }
 
 
@@ -462,39 +497,6 @@ bool CTBModule::read( T &obj) {
   }
 
   return true ;
-}
-
-uint64_t CTBModule::MatchTriggerInput(const content::word::trigger_t * trigger, const std::pair<uint64_t,uint64_t> &prev_input, const std::pair<uint64_t,uint64_t> &prev_prev_input, bool hlt_matching) noexcept {
- 
-  // The first condition should be true the majority of the time and the "else" should never happen.
-  // Find the matching word whcih caused the LLT or HLT and return its payload
-  uint64_t trigger_ts = trigger->timestamp;
-  uint64_t trigger_word = trigger->trigger_word;
-  
-  if ( trigger_ts == prev_input.first + 1 ) { 
-    return prev_input.second; 
-  } 
-  else if( trigger_ts == prev_prev_input.first + 1 ) { 
-    return prev_prev_input.second; 
-  } 
-  else {
-    std::stringstream msg;
-    if ( hlt_matching ) { 
-      if (trigger_word == 0x1 || trigger_word == (0x1<<16)) {
-        // we don't care if fake trigger (HLT0) or the pulse train (HLT 16) have no matching LLTs
-        return 0;
-      }
-      msg << "No LLT m/atch found for HLT TS " << trigger_ts << " (LLT TS prev=" 
-          << prev_input.first << " prev_prev=" << prev_prev_input.first << ")";
-    } 
-    else {
-      msg << "No Channel Status match found for LLT TS " << trigger_ts << " (Channel Status TS prev=" 
-          << prev_input.first << " prev_prev=" << prev_prev_input.first << ")";
-    }
-    ers::error(CTBWordMatchError(ERS_HERE, msg.str()));
-    return 0;
-  }
-
 }
 
 bool CTBModule::IsTSWord( const content::word::word_t &w ) noexcept {

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -411,11 +411,11 @@ bool CTBModule::check_repeated_word(ts_payload& curr_word, ts_payload& prev_word
     else msg << wtype;
     msg << ", TS: "<< curr_word.first << ".";
     if (curr_word.second != prev_word.second) { // not only do we have repeated timestamp, they have different payload...
-      msg << " Different payload!! Previous payload: " << std::hex << prev_word.second
-          << " Current payload: " << curr_word.second;
+      msg << " Different payload!! Previous payload: 0x" << std::hex << prev_word.second
+          << " Current payload: 0x" << curr_word.second;
       ers::warning(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
     } else {
-      msg << "Both have payload " << std::hex << prev_word.second;
+      msg << " Both have payload 0x" << std::hex << prev_word.second;
       ers::info(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
     }
     return true;
@@ -471,8 +471,8 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
     if (timeout_reference > (trigger_ts + 100)) {
       std::stringstream msg;
       msg << "Time out while waiting for a match for the "<< (is_hlt? "HLT" : "LLT")
-          << ": TS = " << trigger_ts << ", trigger word = " << trigger_word
-          << " Timeout reference: " << timeout_reference;
+          << ": TS = " << trigger_ts << ", trigger word = " << std::hex << "0x"<< trigger_word
+          << " Timeout reference: " << std::dec << timeout_reference;
       ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
       buf_a.pop();
       continue;
@@ -496,7 +496,7 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
         else{
           std::stringstream msg;
           msg << "No match found for " << (is_hlt? "HLT" : "LLT")
-              << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
+              << ": TS = " << trigger_ts << ", trigger word = 0x" << std::hex << trigger_word;
           ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
         }
         buf_a.pop();

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -26,6 +26,10 @@
 #define TRACE_NAME "CTBModule" // NOLINT
 #define TLVL_ENTER_EXIT_METHODS 10
 #define TLVL_CTB_MODULE 15
+#define CTB_HSI_FRAME_VERSION 0x1
+#define CTB_HSI_DET_ID 0x1
+#define CTB_HSI_CRATE_ID 0x0
+#define CTB_HSI_SLOT_ID 0x0
 
 namespace dunedaq {
 namespace ctbmodules {
@@ -312,33 +316,9 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
         // Now find the associated LLT
         // if HLT0, skip matching
         llt_payload = MatchTriggerInput( hlt_word, prev_llt, prev_prev_llt, true );
+        
+        send_trigger_word(hlt_word, llt_payload);
     
-        // Send HSI data to a DLH 
-        std::array<uint32_t, 7> hsi_struct;
-        hsi_struct[0] = (0x1 << 26) | (0x1 << 6) | 0x1; // DAQHeader, frame version: 1, det id: 1, link for low level 0, link for high level 1, leave slot and crate as 0
-        hsi_struct[1] = hlt_word->timestamp;       // ts low
-        hsi_struct[2] = hlt_word->timestamp >> 32; // ts high
-        hsi_struct[3] = llt_payload;               // lower 32b 
-        hsi_struct[4] = 0x0;                       // max 32 llts so these bits will always be 0x0
-        hsi_struct[5] = hlt_word->trigger_word;    // trigger_map;
-        hsi_struct[6] = m_run_HLT_counter;         // m_generated_counter;
-  
-        TLOG_DEBUG(4) << get_name() << ": Formed HSI_FRAME_STRUCT for hlt "
-              << std::hex 
-              << "0x"   << hsi_struct[0]
-              << ", 0x" << hsi_struct[1]
-              << ", 0x" << hsi_struct[2]
-              << ", 0x" << hsi_struct[3]
-              << ", 0x" << hsi_struct[4]
-              << ", 0x" << hsi_struct[5]
-              << ", 0x" << hsi_struct[6]
-              << "\n";
-  
-        send_raw_hsi_data(hsi_struct, m_hlt_hsi_data_sender.get());
-
-        // TODO properly fill device id
-        dfmessages::HSIEvent event = dfmessages::HSIEvent(0x1, hlt_word->trigger_word, hlt_word->timestamp, m_run_HLT_counter, m_run_number);
-        send_hsi_event(event);
 
         // Count the total HLTs and each specific one
         ++m_total_hlt_counter;
@@ -352,29 +332,8 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
 
         // Find the matching channel status word
         channel_payload = MatchTriggerInput( llt_word, prev_channel, prev_prev_channel, false );
-  
-        // Send HSI data to a DLH 
-        std::array<uint32_t, 7> hsi_struct;
-        hsi_struct[0] = (0x1 << 6) | 0x1; // DAQHeader, frame version: 1, det id: 1, link for low level 0, link for high level 1, leave slot and crate as 0
-        hsi_struct[1] = llt_word->timestamp;       // ts low
-        hsi_struct[2] = llt_word->timestamp >> 32; // ts high
-        hsi_struct[3] = channel_payload;           // channel raw input lower 32b
-        hsi_struct[4] = channel_payload >> 32;     // channelraw input upper 32b
-        hsi_struct[5] = llt_word->trigger_word;    // trigger_map;
-        hsi_struct[6] = m_run_LLT_counter;         // m_generated_counter;
-  
-        TLOG_DEBUG(6) << get_name() << ": Formed HSI_FRAME_STRUCT for llt "
-              << std::hex 
-              << "0x"   << hsi_struct[0]
-              << ", 0x" << hsi_struct[1]
-              << ", 0x" << hsi_struct[2]
-              << ", 0x" << hsi_struct[3]
-              << ", 0x" << hsi_struct[4]
-              << ", 0x" << hsi_struct[5]
-              << ", 0x" << hsi_struct[6]
-              << "\n";
-
-        send_raw_hsi_data(hsi_struct, m_llt_hsi_data_sender.get());
+        
+        send_trigger_word(llt_word, channel_payload);
 
         // store the previous 2 LLTs so we can match to the HLT
         prev_prev_llt = prev_llt;
@@ -438,6 +397,45 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
   
   TLOG_DEBUG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
 
+}
+
+void CTBModule::send_trigger_word(content::word::trigger_t* word, uint64_t payload) {
+  // Send HSI data to a DLH
+  std::array<uint32_t, 7> hsi_struct;
+  bool is_hlt = word->IsHLT();
+  hsi_struct[0] = (is_hlt << 26)            |  // link
+                  (CTB_HSI_SLOT_ID << 22)   |  
+                  (CTB_HSI_CRATE_ID << 12)  | 
+                  (CTB_HSI_DET_ID << 6)     |
+                  CTB_HSI_FRAME_VERSION
+                  ;
+  hsi_struct[1] = word->timestamp;        // ts low
+  hsi_struct[2] = word->timestamp >> 32;  // ts high
+  hsi_struct[3] = payload;                // lower 32b
+  hsi_struct[4] = payload >> 32;          // upper 32b (will be 0x0 for llt payloads)
+  hsi_struct[5] = word->trigger_word;     // trigger_map;
+  hsi_struct[6] = is_hlt ? m_run_HLT_counter : m_run_LLT_counter; // m_generated_counter;
+  int dbg_lvl = is_hlt ? 4 : 6;
+  TLOG_DEBUG(dbg_lvl) << get_name() << ": Formed HSI_FRAME_STRUCT for" << (is_hlt? "HLT" : "LLT")
+      << std::hex 
+      << "0x"   << hsi_struct[0]
+      << ", 0x" << hsi_struct[1]
+      << ", 0x" << hsi_struct[2]
+      << ", 0x" << hsi_struct[3]
+      << ", 0x" << hsi_struct[4]
+      << ", 0x" << hsi_struct[5]
+      << ", 0x" << hsi_struct[6]
+      << "\n";
+  if (is_hlt) {
+    send_raw_hsi_data(hsi_struct, m_hlt_hsi_data_sender.get());
+    // TODO properly fill device id
+    dfmessages::HSIEvent event(0x1, word->trigger_word, word->timestamp, m_run_HLT_counter, m_run_number);
+    send_hsi_event(event);
+  }
+  else {
+    send_raw_hsi_data(hsi_struct, m_llt_hsi_data_sender.get());
+  }
+  
 }
 
 

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -357,8 +357,10 @@ CTBModule::do_hsi_work(std::atomic<bool>& running_flag)
         ++m_run_channel_status_counter;
       }
       // do matching
-      match_between_buffers(match_buf_a_hlts, match_buf_b_llts, prev_hlt.first);
-      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, prev_llt.first);
+      match_between_buffers(match_buf_a_hlts, match_buf_b_llts, 
+          prev_hlt.first, content::word::word_type::t_gt);
+      match_between_buffers(match_buf_a_llts, match_buf_b_chstatus, 
+          prev_llt.first, content::word::word_type::t_lt);
 
     } // n_words loop
 
@@ -416,14 +418,14 @@ bool CTBModule::check_repeated_word(ts_payload& curr_word, ts_payload& prev_word
       ers::warning(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
     } else {
       msg << " Both have payload 0x" << std::hex << prev_word.second;
-      ers::info(CTBRepeatedTimestampWarning(ERS_HERE, msg.str()));
+      TLOG() << msg.str();
     }
     return true;
   }
   return false;
 }
 
-void CTBModule::send_matched_trigger_word(content::word::trigger_t& word, uint64_t payload) {
+void CTBModule::send_matched_trigger_word(const content::word::trigger_t& word, uint64_t payload) {
   // Send HSI data to a DLH
   std::array<uint32_t, 7> hsi_struct;
   bool is_hlt = word.IsHLT();
@@ -462,10 +464,10 @@ void CTBModule::send_matched_trigger_word(content::word::trigger_t& word, uint64
   
 }
 
-void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_a, std::queue<ts_payload>& buf_b, uint64_t timeout_reference) {
+void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_a, std::queue<ts_payload>& buf_b, uint64_t timeout_reference, content::word::word_type buf_a_wtype) {
+  bool is_hlt = (buf_a_wtype == content::word::word_type::t_gt);
   while (buf_a.size() > 0) {
     content::word::trigger_t trigger = buf_a.front();
-    bool is_hlt = trigger.IsHLT();
     uint64_t trigger_ts = trigger.timestamp;
     uint64_t trigger_word = trigger.trigger_word;
     if (timeout_reference > (trigger_ts + 100)) {
@@ -481,11 +483,15 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
     while (buf_b.size() > 0) {
       uint64_t input_ts = buf_b.front().first;
       if (input_ts < (trigger_ts - 1)) { // word is too early. No longer needed
+        if (is_hlt) last_popped_llt = buf_b.front();
+        else last_popped_chstatus = buf_b.front();
         buf_b.pop();
       }
       else if (input_ts == (trigger_ts - 1)) { // match is found
         send_matched_trigger_word(trigger, buf_b.front().second);
         buf_a.pop();
+        if (is_hlt) last_popped_llt = buf_b.front();
+        else last_popped_chstatus = buf_b.front();
         buf_b.pop();
         break;
       }
@@ -496,7 +502,9 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
         else{
           std::stringstream msg;
           msg << "No match found for " << (is_hlt? "HLT" : "LLT")
-              << ": TS = " << trigger_ts << ", trigger word = 0x" << std::hex << trigger_word;
+              << ": TS = " << trigger_ts << ", trigger word = 0x" << std::hex << trigger_word
+              << " Adjacent input ts: " << std::dec << (is_hlt? last_popped_llt.first : last_popped_chstatus.first) << " "
+              << input_ts;
           ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
         }
         buf_a.pop();
@@ -505,7 +513,11 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
     } // end loop buf_b
   } // end loop buf_a
   // Don't let buf_b get too long (e.g. when LLT rate is high but HLT rate is low)
-  while (buf_b.size() > 32) buf_b.pop();
+  while (buf_b.size() > 32) {
+    if (is_hlt) last_popped_llt = buf_b.front();
+    else last_popped_chstatus = buf_b.front();
+    buf_b.pop();
+  }
 }
 
 

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -440,7 +440,7 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
       std::stringstream msg;
       msg << "Time out while waiting for a match for the "<< (is_hlt? "HLT" : "LLT")
           << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
-      ers::warning(CTBWordMatchError(ERS_HERE, msg.str()));
+      ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
       buf_a.pop();
       continue;
     }
@@ -464,10 +464,10 @@ void CTBModule::match_between_buffers(std::queue<content::word::trigger_t>& buf_
           std::stringstream msg;
           msg << "No match found for " << (is_hlt? "HLT" : "LLT")
               << ": TS = " << trigger_ts << ", trigger word = " << trigger_word;
-          ers::warning(CTBWordMatchError(ERS_HERE, msg.str()));
+          ers::warning(CTBWordMatchWarning(ERS_HERE, msg.str()));
         }
         buf_a.pop();
-        continue;
+        break;
       }
     } // end loop buf_b
   }

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -36,6 +36,7 @@
 #include <boost/asio.hpp>
 #include <boost/array.hpp>
 
+
 namespace dunedaq {
 namespace ctbmodules {
 
@@ -114,6 +115,7 @@ private:
   // Threading
   dunedaq::utilities::WorkerThread m_thread_;
   void do_hsi_work(std::atomic<bool>&);
+  void send_trigger_word(content::word::trigger_t *, uint64_t);
 
   template<typename T>
   bool read(T &obj);

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -40,6 +40,8 @@
 namespace dunedaq {
 namespace ctbmodules {
 
+typedef std::pair<uint64_t,uint64_t> ts_payload;
+
 /**
  * @brief CTBModule provides the command and readout interface to the Central Trigger Board hardware
  */
@@ -60,7 +62,6 @@ public:
 
   void init(const nlohmann::json& iniobj) override;
 
-  static uint64_t MatchTriggerInput(const content::word::trigger_t * trigger, const std::pair<uint64_t,uint64_t> &prev_input, const std::pair<uint64_t,uint64_t> &prev_prev_input, bool hlt_matching) noexcept;
   static bool IsTSWord( const content::word::word_t &w ) noexcept;
   static bool IsFeedbackWord( const content::word::word_t &w ) noexcept;
   bool ErrorState() const { return m_error_state.load() ; } 
@@ -115,7 +116,11 @@ private:
   // Threading
   dunedaq::utilities::WorkerThread m_thread_;
   void do_hsi_work(std::atomic<bool>&);
-  void send_trigger_word(content::word::trigger_t *, uint64_t);
+
+  // Generate HSI Frame/Event
+  void send_matched_trigger_word(content::word::trigger_t&, uint64_t);
+  void match_between_buffers(std::queue<content::word::trigger_t>&, std::queue<ts_payload>&, uint64_t);
+  
 
   template<typename T>
   bool read(T &obj);

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -120,6 +120,8 @@ private:
   // Generate HSI Frame/Event
   void send_matched_trigger_word(content::word::trigger_t&, uint64_t);
   void match_between_buffers(std::queue<content::word::trigger_t>&, std::queue<ts_payload>&, uint64_t);
+
+  static bool check_repeated_word(ts_payload&, ts_payload&, uint64_t);
   
 
   template<typename T>
@@ -173,7 +175,6 @@ private:
   std::atomic<int> m_num_control_messages_sent;
   std::atomic<int> m_num_control_responses_received;
   std::atomic<uint64_t> m_last_readout_hlt_timestamp; // NOLINT(build/unsigned)
-  std::atomic<uint64_t> m_last_readout_llt_timestamp; // NOLINT(build/unsigned)
 
 };
 } // namespace ctbmodule

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -98,6 +98,8 @@ private:
   std::shared_ptr<dunedaq::hsilibs::HSIEventSender::raw_sender_ct> m_llt_hsi_data_sender;
   std::shared_ptr<dunedaq::hsilibs::HSIEventSender::raw_sender_ct> m_hlt_hsi_data_sender;
 
+  ts_payload last_popped_llt, last_popped_chstatus;
+
 
   // Commands
   void do_configure(const nlohmann::json& obj);
@@ -118,8 +120,8 @@ private:
   void do_hsi_work(std::atomic<bool>&);
 
   // Generate HSI Frame/Event
-  void send_matched_trigger_word(content::word::trigger_t&, uint64_t);
-  void match_between_buffers(std::queue<content::word::trigger_t>&, std::queue<ts_payload>&, uint64_t);
+  void send_matched_trigger_word(const content::word::trigger_t&, uint64_t);
+  void match_between_buffers(std::queue<content::word::trigger_t>&, std::queue<ts_payload>&, uint64_t, content::word::word_type);
 
   static bool check_repeated_word(ts_payload&, ts_payload&, uint64_t);
   

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -173,6 +173,7 @@ private:
   std::atomic<int> m_num_control_messages_sent;
   std::atomic<int> m_num_control_responses_received;
   std::atomic<uint64_t> m_last_readout_hlt_timestamp; // NOLINT(build/unsigned)
+  std::atomic<uint64_t> m_last_readout_llt_timestamp; // NOLINT(build/unsigned)
 
 };
 } // namespace ctbmodule

--- a/src/CTBModuleIssues.hpp
+++ b/src/CTBModuleIssues.hpp
@@ -34,6 +34,11 @@ ERS_DECLARE_ISSUE(ctbmodules,
                   " CTB Word Matching Issue: " << descriptor, 
                   ((std::string)descriptor))
 
+ERS_DECLARE_ISSUE(ctbmodules, 
+                  CTBRepeatedTimestampWarning, 
+                  " CTB Repeated Word Issue: " << descriptor, 
+                  ((std::string)descriptor))
+
 ERS_DECLARE_ISSUE(ctbmodules,
                   CTBMessage,
                   " Mesage from CTB: " << descriptor,

--- a/src/CTBModuleIssues.hpp
+++ b/src/CTBModuleIssues.hpp
@@ -30,8 +30,8 @@ ERS_DECLARE_ISSUE(ctbmodules,
                   ((std::string)descriptor))
 
 ERS_DECLARE_ISSUE(ctbmodules, 
-                  CTBWordMatchError, 
-                  " CTB Word Matching Error: " << descriptor, 
+                  CTBWordMatchWarning, 
+                  " CTB Word Matching Issue: " << descriptor, 
                   ((std::string)descriptor))
 
 ERS_DECLARE_ISSUE(ctbmodules,


### PR DESCRIPTION
- Input to trigger matching is now done with a `std::queue`, where unmatched words are allowed to persist (and wait for the input word to come in) for a fixed period of time. 
- CTB Word matching issues have been reduced from an ERROR to a WARNING.