### PR TITLE
Remove obsolete file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(ctbmodules VERSION 2.3.0)
+project(ctbmodules VERSION 2.4.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/CTBModule.cpp
+++ b/plugins/CTBModule.cpp
@@ -134,12 +134,6 @@ CTBModule::do_configure(const data_t& args)
     m_calibration_file_interval = std::chrono::minutes(m_cfg.calibration_update); 
   }
 
-  if ( m_cfg.run_trigger_output != "" ) {
-    m_has_run_trigger_report = true ; 
-    m_run_trigger_dir = m_cfg.run_trigger_output;
-    if ( m_run_trigger_dir.back() != '/' ) m_run_trigger_dir += '/' ;
-  }
-
   // create the json string
   nlohmann::json config;
   to_json(config, m_cfg.board_config);
@@ -202,7 +196,6 @@ CTBModule::do_stop(const nlohmann::json& /*stopobj*/)
   else{
     throw CTBCommunicationError(ERS_HERE, "Unable to stop CTB");
   }
-  store_run_trigger_counters( m_run_number ) ; 
   m_thread_.stop_working_thread();
 
   m_run_HLT_counter=0;
@@ -564,26 +557,6 @@ bool CTBModule::SetCalibrationStream( const std::string & prefix ) {
   } 
   // possibly we could check here if the directory is valid and  writable before assuming the calibration stream is valid
   return true ;
-
-}
-
-bool CTBModule::store_run_trigger_counters( unsigned int run_number, const std::string & prefix) const {
-
-  if ( ! m_has_run_trigger_report ) {
-    return false ;
-  }
-
-  std::stringstream out_name ;
-  out_name << m_run_trigger_dir << prefix << "run_" << run_number << "_triggers.txt";
-  std::ofstream out( out_name.str() ) ;
-  out << "Good Part\t " << m_run_gool_part_counter << std::endl 
-      << "Total HLT\t " << m_run_HLT_counter << std::endl ;
-
-  for ( unsigned int i = 0; i < m_metric_HLT_names.size() ; ++i ) {
-    out << "HLT " << i << " \t " << m_run_HLT_counters[i] << std::endl ;
-  }
-
-  return true; 
 
 }
 

--- a/plugins/CTBModule.hpp
+++ b/plugins/CTBModule.hpp
@@ -131,33 +131,12 @@ private:
   std::ofstream m_calibration_file;
   std::chrono::steady_clock::time_point m_last_calibration_file_update;
 
-  // members related to run trigger report
-
-  bool m_has_run_trigger_report = false;
-  std::string m_run_trigger_dir = "";
-  bool store_run_trigger_counters( unsigned int run_number, const std::string & prefix = "" ) const;
-
-
-  std::atomic<unsigned long> m_run_gool_part_counter = 0;
+  // metric utilities
   std::atomic<unsigned long> m_run_HLT_counter = 0;
-  // TODO should be atomic?
-  unsigned long m_run_HLT_counters[8] = {0};
   std::atomic<unsigned long> m_run_LLT_counter;
   std::atomic<unsigned long> m_run_channel_status_counter = 0;
-  // metric utilities
-
-  const std::array<std::string, 8> m_metric_HLT_names  = { "CTB_HLT_0_rate",
-                                                            "CTB_HLT_1_rate", 
-                                                            "CTB_HLT_2_rate",
-                                                            "CTB_HLT_3_rate",
-                                                            "CTB_HLT_4_rate",
-                                                            "CTB_HLT_5_rate",
-                                                            "CTB_HLT_6_rate",
-                                                            "CTB_HLT_7_rate" };
-
 
   // monitoring
-
   std::deque<uint> m_buffer_counts; // NOLINT(build/unsigned)
   std::shared_mutex m_buffer_counts_mutex;
   void update_buffer_counts(uint new_count); // NOLINT(build/unsigned)

--- a/schema/ctbmodules/ctbmodule.jsonnet
+++ b/schema/ctbmodules/ctbmodule.jsonnet
@@ -231,9 +231,6 @@ local ctbmodule = {
 
         s.field("calibration_update", self.uint8, "5",
                 doc="CTB Calibration Update Interval"),
-
-        s.field("run_trigger_output", self.string, "/nfs/sw/trigger/counters",
-                doc="CTB Trigger Output Path"),
  
         s.field("board_config", self.board_config, self.board_config, doc="CTB board config"),
 


### PR DESCRIPTION
In protoDUNE 1, at the end of the run the CTBModule was creating a file that contained the number of trigger (per type) generated in the run. 
The implementation was still there but it was not maintained correctly the only one number made sense, which is the total HSI event sent. 

So I removed the code. for the ProtoDUNE 2 run.